### PR TITLE
Use "node-fetch" instead of "download-file" for downloading files

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "bluebird": "^3.5.1",
-    "download-file": "^0.1.5",
     "fs-extra": "^7.0.0",
+    "node-fetch": "^2.2.0",
     "node-notifier": "^5.2.1",
     "opn": "^5.3.0",
     "twitch-api-v5": "^2.0.4"

--- a/src/downloadFile.js
+++ b/src/downloadFile.js
@@ -1,23 +1,18 @@
 // @flow
 
 import path from 'path';
-import download from 'download-file';
+import fs from 'fs';
+import fetch from 'node-fetch';
 
-export default function downloadFile(url: string, outputPath: string): Promise<void> {
-  const { dir, base } = path.parse(outputPath);
+export default async function downloadFile(url: string, outputPath: string): Promise<void> {
+  const writeStream = fs.createWriteStream(outputPath);
 
-  const options = {
-    directory: dir,
-    filename: base,
-  };
+  const response = await fetch(url);
+
+  response.body.pipe(writeStream);
 
   return new Promise((resolve, reject) => {
-    download(url, options, (error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
+    writeStream.on('error', (error) => reject(error));
+    writeStream.on('close', () => resolve());
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ async function main() {
 
   console.log('Downloading and transcoding...');
 
+  await fse.ensureDir(downloadDirectory);
   await fse.ensureDir(tempRoot);
 
   const transcodedVideos = await Bluebird.map(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,12 +1397,6 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
-download-file@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/download-file/-/download-file-0.1.5.tgz#ca50ba64d9094b0c8702ef9fff92d2189e141117"
-  dependencies:
-    mkdirp "^0.5.0"
-
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
@@ -3050,7 +3044,7 @@ nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
 
-node-fetch@^2.1.1:
+node-fetch@^2.1.1, node-fetch@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
 


### PR DESCRIPTION
[node-fetch](https://github.com/bitinn/node-fetch) is a library that has a [WHATWG Fetch](https://github.com/whatwg/fetch)-compatible API and is used to fetch resources over HTTP(S). 

I think it is better that we use this commonly known and used library for downloading files instead of "download-file" which is a 4 year old library that doesn't even provide us with a repository URL that we can contribute to.