### PR TITLE
Improve FfmpegHelper

### DIFF
--- a/src/FfmpegHelper.js
+++ b/src/FfmpegHelper.js
@@ -47,26 +47,23 @@ export default class FfmpegHelper {
     return promiseFromChildProcess(ffmpeg);
   }
 
-  async concatVideos(
-    videoPaths: Array<string>,
-    outputPath: string,
-    tempListPath: string,
-  ): Promise<void> {
-    const listPath = tempListPath;
-
-    await fse.writeFile(listPath, videoPaths.map((f) => `file '${f}'`).join('\n'));
-
+  async concatVideos(videoPaths: Array<string>, outputPath: string): Promise<void> {
     const ffmpeg = this.spawn(
       // prettier-ignore
       [
         '-f', 'concat',
         '-safe', '0',
-        '-i', listPath,
+        '-protocol_whitelist', 'pipe,file',
+        '-i', '-',
         '-c', 'copy',
         outputPath,
         '-y'
       ],
     );
+
+    const list = videoPaths.map((f) => `file '${f}'`).join('\n');
+    ffmpeg.stdin.write(list);
+    ffmpeg.stdin.end();
 
     return promiseFromChildProcess(ffmpeg);
   }

--- a/src/FfmpegHelper.js
+++ b/src/FfmpegHelper.js
@@ -1,7 +1,22 @@
 // @flow
 
-import child_process from 'child_process';
+import child_process, { type ChildProcess } from 'child_process';
 import fse from 'fs-extra';
+
+function promiseFromChildProcess(childProcess: ChildProcess): Promise<void> {
+  return new Promise((resolve, reject) => {
+    childProcess.on('error', (error) => {
+      reject(error);
+    });
+    childProcess.on('exit', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Process exited with "${code}"`));
+      }
+
+      resolve();
+    });
+  });
+}
 
 export default class FfmpegHelper {
   command: string;
@@ -10,29 +25,26 @@ export default class FfmpegHelper {
     this.command = command;
   }
 
-  async transcodeVideo(inputPath: string, outputPath: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      child_process.exec(
-        this.command +
-          ' -i ' +
-          inputPath +
-          ' -vf setdar=16/9 -video_track_timescale 60000 -ac 1 -ar 48000 -preset ultrafast ' +
-          // '-vf "[in]drawtext=fontfile=misc/segoeuil.ttf: text=\'twitch.tv/' + parser.clipList[index].broadcaster.name +
-          // '\': fontcolor=black: fontsize=20: box=1: boxcolor=white@0.9: boxborderw=10: x=(w-text_w)-10: y=40,' +
-          // 'drawtext=fontfile=misc/segoeuil.ttf: text=' + parser.clipList[index].game.replace(':', '') +
-          // '\': fontcolor=black: fontsize=20: box=1: boxcolor=white@0.9: boxborderw=10: x=(w-text_w)-10: y=100" ' +
-          outputPath +
-          ' -y',
-        (error, stdout, stderr) => {
-          if (error) {
-            reject(error);
-            return;
-          }
+  spawn(args: Array<string>, options?: child_process$spawnOpts): ChildProcess {
+    return child_process.spawn(this.command, args, options);
+  }
 
-          resolve();
-        },
-      );
-    });
+  async transcodeVideo(inputPath: string, outputPath: string): Promise<void> {
+    const ffmpeg = this.spawn(
+      // prettier-ignore
+      [
+        '-i', inputPath,
+        '-vf', 'setdar=16/9',
+        '-video_track_timescale', '60000',
+        '-ac', '1',
+        '-ar', '48000',
+        '-preset', 'ultrafast',
+        outputPath,
+        '-y',
+      ],
+    );
+
+    return promiseFromChildProcess(ffmpeg);
   }
 
   async concatVideos(
@@ -44,17 +56,18 @@ export default class FfmpegHelper {
 
     await fse.writeFile(listPath, videoPaths.map((f) => `file '${f}'`).join('\n'));
 
-    return new Promise((resolve, reject) => {
-      child_process.exec(
-        this.command + ' -f concat -safe 0 -i ' + listPath + ' -c copy ' + outputPath + ' -y',
-        (error, stdout, stderr) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        },
-      );
-    });
+    const ffmpeg = this.spawn(
+      // prettier-ignore
+      [
+        '-f', 'concat',
+        '-safe', '0',
+        '-i', listPath,
+        '-c', 'copy',
+        outputPath,
+        '-y'
+      ],
+    );
+
+    return promiseFromChildProcess(ffmpeg);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ async function main() {
 
   console.log('Merging...');
 
-  await ffmpegHelper.concatVideos(files, outputPath, path.join(projectRoot, './tmp/mylist.txt'));
+  await ffmpegHelper.concatVideos(files, outputPath);
 
   console.log('Done!');
 


### PR DESCRIPTION
This PR has two commits. The first one just cleans up the module which shouldn't cause any regressions.

The second commit improves `concatVideos()` so it pipes the list of files to FFmpeg instead of saving it to a file. I have tested this manually on macOS and didn't observe any regressions, but it should also be tested on Windows.